### PR TITLE
prevent scanning interfaces and traits

### DIFF
--- a/src/Driver/AbstractClassDriver.php
+++ b/src/Driver/AbstractClassDriver.php
@@ -70,15 +70,23 @@ abstract class AbstractClassDriver extends AbstractDriver
                 ++$next;
             }
 
-            $next = $this->findNextToken($tokens, \T_CLASS, $next + 1, \T_DOUBLE_COLON);
-            if ($next !== null) {
-                $next = $this->findNextToken($tokens, \T_STRING, $next + 1);
-                if ($next !== null) {
-                    $class .= '\\' . $tokens[$next][1];
-                }
-            } else {
+            if (
+                $this->findNextToken($tokens, \T_TRAIT, $next + 1) !== null // Exclude traits
+                || $this->findNextToken($tokens, \T_INTERFACE, $next + 1) !== null // Exclude interfaces
+            ) {
                 return null;
             }
+
+            $next = $this->findNextToken($tokens, \T_CLASS, $next + 1, \T_DOUBLE_COLON);
+            if ($next === null) {
+                return null;
+            }
+
+            $next = $this->findNextToken($tokens, \T_STRING, $next + 1);
+            if ($next !== null) {
+                $class .= '\\' . $tokens[$next][1];
+            }
+
         }
 
         /** @var class-string<object> $class */

--- a/src/Driver/AbstractClassDriver.php
+++ b/src/Driver/AbstractClassDriver.php
@@ -44,7 +44,7 @@ abstract class AbstractClassDriver extends AbstractDriver
     /**
      * Load fully qualified class name from file.
      *
-     * @return null|class-string<object>
+     * @return class-string<object>|null
      */
     protected function loadClassFromFile(string $mappingFile): ?string
     {
@@ -53,12 +53,9 @@ abstract class AbstractClassDriver extends AbstractDriver
 
         $class = '';
 
-        $next = $this->findNextToken($tokens, \T_NAMESPACE);
+        $next = $this->findNextToken($tokens, [\T_NAMESPACE]);
         if ($next !== null) {
-            $validTokenTypes = [\T_WHITESPACE, \T_NS_SEPARATOR, \T_STRING];
-            if (\PHP_VERSION_ID >= 80_000) {
-                $validTokenTypes[] = T_NAME_QUALIFIED;
-            }
+            $validTokenTypes = $this->getValidTokenTypes();
 
             while (
                 \array_key_exists($next + 1, $tokens)
@@ -70,23 +67,20 @@ abstract class AbstractClassDriver extends AbstractDriver
                 ++$next;
             }
 
-            if (
-                $this->findNextToken($tokens, \T_TRAIT, $next + 1) !== null // Exclude traits
-                || $this->findNextToken($tokens, \T_INTERFACE, $next + 1) !== null // Exclude interfaces
-            ) {
+            // Exclude traits and interfaces
+            if ($this->findNextToken($tokens, [\T_TRAIT, \T_INTERFACE], $next + 1) !== null) {
                 return null;
             }
 
-            $next = $this->findNextToken($tokens, \T_CLASS, $next + 1, \T_DOUBLE_COLON);
+            $next = $this->findNextToken($tokens, [\T_CLASS], $next + 1, \T_DOUBLE_COLON);
             if ($next === null) {
                 return null;
             }
 
-            $next = $this->findNextToken($tokens, \T_STRING, $next + 1);
+            $next = $this->findNextToken($tokens, [\T_STRING], $next + 1);
             if ($next !== null) {
                 $class .= '\\' . $tokens[$next][1];
             }
-
         }
 
         /** @var class-string<object> $class */
@@ -97,8 +91,9 @@ abstract class AbstractClassDriver extends AbstractDriver
      * Traverse token stack in search of next token.
      *
      * @param array<mixed|array{0: int, 1: string, 2: int}> $tokens
+     * @param array<int>                                    $types
      */
-    private function findNextToken(array $tokens, int $type, int $start = 0, ?int $escapePreviousType = null): ?int
+    private function findNextToken(array $tokens, array $types, int $start = 0, ?int $escapePreviousType = null): ?int
     {
         $previousToken = false;
 
@@ -109,7 +104,7 @@ abstract class AbstractClassDriver extends AbstractDriver
             }
 
             if (
-                $token[0] === $type
+                \in_array($token[0], $types, true)
                 && (
                     $escapePreviousType === null
                     || !\is_array($previousToken)
@@ -123,5 +118,18 @@ abstract class AbstractClassDriver extends AbstractDriver
         }
 
         return null;
+    }
+
+    /**
+     * @return array<int>
+     */
+    private function getValidTokenTypes(): array
+    {
+        $validTokenTypes = [\T_WHITESPACE, \T_NS_SEPARATOR, \T_STRING];
+        if (\PHP_VERSION_ID >= 80_000) {
+            $validTokenTypes[] = T_NAME_QUALIFIED;
+        }
+
+        return $validTokenTypes;
     }
 }

--- a/src/Driver/AbstractClassDriver.php
+++ b/src/Driver/AbstractClassDriver.php
@@ -44,9 +44,9 @@ abstract class AbstractClassDriver extends AbstractDriver
     /**
      * Load fully qualified class name from file.
      *
-     * @return class-string<object>
+     * @return null|class-string<object>
      */
-    protected function loadClassFromFile(string $mappingFile): string
+    protected function loadClassFromFile(string $mappingFile): ?string
     {
         $content = file_get_contents($mappingFile);
         $tokens = token_get_all($content !== false ? $content : '');
@@ -76,6 +76,8 @@ abstract class AbstractClassDriver extends AbstractDriver
                 if ($next !== null) {
                     $class .= '\\' . $tokens[$next][1];
                 }
+            } else {
+                return null;
             }
         }
 

--- a/tests/Mapping/Driver/AbstractClassDriverTest.php
+++ b/tests/Mapping/Driver/AbstractClassDriverTest.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * mapping (https://github.com/juliangut/mapping).
+ * Mapping parsing base library.
+ *
+ * @license BSD-3-Clause
+ * @link https://github.com/juliangut/mapping
+ * @author Julián Gutiérrez <juliangut@gmail.com>
+ */
+
+declare(strict_types=1);
+
+namespace Jgut\Mapping\Tests\Driver;
+
+use Jgut\Mapping\Tests\Files\Classes\Valid\Attribute\ClassA;
+use Jgut\Mapping\Tests\Stubs\AbstractClassDriverStub;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @internal
+ */
+class AbstractClassDriverTest extends TestCase
+{
+    public function testClassLoader(): void
+    {
+        $driver = new AbstractClassDriverStub([__DIR__ . '/../Files/Classes/Valid/Attribute']);
+
+        $className = $driver->loadClassFromFile(__DIR__ . '/../Files/Classes/Valid/Attribute/ClassA.php');
+        $traitName = $driver->loadClassFromFile(__DIR__ . '/../Files/Classes/Invalid/Attribute/Trait.php');
+        $interfaceName = $driver->loadClassFromFile(__DIR__ . '/../Files/Classes/Invalid/Attribute/Interface.php');
+
+        static::assertSame(ClassA::class, $className);
+        static::assertNull($traitName);
+        static::assertNull($interfaceName);
+    }
+}

--- a/tests/Mapping/Files/Classes/Invalid/Attribute/Interface.php
+++ b/tests/Mapping/Files/Classes/Invalid/Attribute/Interface.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * mapping (https://github.com/juliangut/mapping).
+ * Mapping parsing base library.
+ *
+ * @license BSD-3-Clause
+ * @link https://github.com/juliangut/mapping
+ * @author Julián Gutiérrez <juliangut@gmail.com>
+ */
+
+declare(strict_types=1);
+
+namespace Jgut\Mapping\Tests\Files\Classes\Invalid\Attribute;
+
+interface InterfaceA
+{
+    public function methodA(): void;
+}

--- a/tests/Mapping/Files/Classes/Invalid/Attribute/Trait.php
+++ b/tests/Mapping/Files/Classes/Invalid/Attribute/Trait.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * mapping (https://github.com/juliangut/mapping).
+ * Mapping parsing base library.
+ *
+ * @license BSD-3-Clause
+ * @link https://github.com/juliangut/mapping
+ * @author Julián Gutiérrez <juliangut@gmail.com>
+ */
+
+declare(strict_types=1);
+
+namespace Jgut\Mapping\Tests\Files\Classes\Invalid\Attribute;
+
+trait TraitA
+{
+    public function methodA(): void
+    {
+    }
+
+    public function methodB(): void
+    {
+        $var = new class() {};
+        echo \get_class($var);
+    }
+}

--- a/tests/Mapping/Stubs/AbstractClassDriverStub.php
+++ b/tests/Mapping/Stubs/AbstractClassDriverStub.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * mapping (https://github.com/juliangut/mapping).
+ * Mapping parsing base library.
+ *
+ * @license BSD-3-Clause
+ * @link https://github.com/juliangut/mapping
+ * @author Julián Gutiérrez <juliangut@gmail.com>
+ */
+
+declare(strict_types=1);
+
+namespace Jgut\Mapping\Tests\Stubs;
+
+use Jgut\Mapping\Driver\AbstractClassDriver;
+use Jgut\Mapping\Metadata\MetadataInterface;
+
+class AbstractClassDriverStub extends AbstractClassDriver
+{
+    /**
+     * Get mapped metadata.
+     *
+     * @return array<MetadataInterface>
+     */
+    public function getMetadata(): array
+    {
+        return [];
+    }
+
+    public function loadClassFromFile(string $mappingFile, bool $uselessVariable = true): ?string
+    {
+        return parent::loadClassFromFile($mappingFile);
+    }
+}


### PR DESCRIPTION
juliangut/mapping tries to make `new ReflectionClass($sourceClass)` of whatever is returned by `loadClassFromFile()`. If there is an interface or a trait in the list of files, `$sourceClass` will be just the namespace (`\T_CLASS` not found) and so an exception is thrown. 

I was thinking about 

- either catching the exception (but then what to do with it)
- adding a `class_exists()` check (this would autoload the class or be potentially wrong)